### PR TITLE
Add support for ChangeHistoryService

### DIFF
--- a/src/init.server.lua
+++ b/src/init.server.lua
@@ -1,4 +1,5 @@
 local CollectionService = game:GetService("CollectionService")
+local HistoryService = game:GetService("ChangeHistoryService")
 local PluginService = plugin
 local ServerStorage = game:GetService("ServerStorage")
 
@@ -254,6 +255,7 @@ end
 
 local function togglePrefabs()
   local arePrefabsShown = getOrCreatePrefabVisibilityState()
+  HistoryService:SetWaypoint("Toggling prefabs")
   if arePrefabsShown.Value then
     hideAllPrefabs()
     removeUnlinkedPlaceholders()
@@ -261,6 +263,7 @@ local function togglePrefabs()
     showAllPrefabs()
   end
   arePrefabsShown.Value = not arePrefabsShown.Value
+  HistoryService:SetWaypoint("Prefabs toggled")
 end
 
 setupContainers()

--- a/src/init.server.lua
+++ b/src/init.server.lua
@@ -234,11 +234,11 @@ local function hidePrefab(_, tag)
         -- function relies on the link to access the associated prefab.
         updatePlaceholderPosition(placeholder)
 
-        placeholder.Link:Destroy()
+        placeholder.Link.Parent = nil
         placeholder.Parent = instance.Parent
       end
 
-      instance:Destroy()
+      instance.Parent = nil
     end
   end
 end
@@ -248,23 +248,34 @@ local hideAllPrefabs = createPrefabModifier(hidePrefab)
 local function removeUnlinkedPlaceholders()
   for _, placeholder in pairs(grabPlaceholderStorage():GetChildren()) do
     if not placeholder:FindFirstChild("Link") or not placeholder.Link.Value then
-      placeholder:Destroy()
+      placeholder.Parent = nil
     end
   end
 end
 
 local function togglePrefabs()
   local arePrefabsShown = getOrCreatePrefabVisibilityState()
+
   HistoryService:SetWaypoint("Toggling prefabs")
+
   if arePrefabsShown.Value then
     hideAllPrefabs()
     removeUnlinkedPlaceholders()
   else
     showAllPrefabs()
   end
+
   arePrefabsShown.Value = not arePrefabsShown.Value
   HistoryService:SetWaypoint("Prefabs toggled")
 end
+
+HistoryService.OnRedo:Connect(function(waypoint)
+  print("redoing", waypoint)
+end)
+
+HistoryService.OnUndo:Connect(function(waypoint)
+  print("undoing", waypoint)
+end)
 
 setupContainers()
 button.Click:Connect(togglePrefabs)


### PR DESCRIPTION
This is for issue #7. Currently undoing doesn't work great. It does seem to work fairly consistently but only after a few undos. It also runs into an issue of trying to undo things that were destroyed, such as the `Link` ObjectValue's and prefab models. This needs further work before it can be merged back into the master.