### PR TITLE
Issues/#29 add support for removing tags

### DIFF
--- a/src/constants.lua
+++ b/src/constants.lua
@@ -40,7 +40,7 @@ return {
     INSERTED = "Inserted prefab",
     UPDATED = "Updated prefab",
     REFRESHED = "Refreshed prefabs",
-    DELETED = "Deleted prefab",
+    CLEAN = "Clean prefab tag",
     DANGEROUSLY_DELETED = "Deleted prefab clones"
   }
 }

--- a/src/prefabs.lua
+++ b/src/prefabs.lua
@@ -259,16 +259,16 @@ return function(plugin)
     HistoryService:SetWaypoint(constants.waypoints.REFRESHED)
   end
 
-  function exports.delete(prefab)
+  function exports.clean(prefab)
     local tag = getPrefabTag(prefab)
 
-    for _, otherPrefab in pairs(getSourcePrefabs()) do
+    for _, otherPrefab in pairs(getAllPrefabs()) do
       if CollectionService:HasTag(otherPrefab, tag) then
-        otherPrefab.Parent = nil
+        CollectionService:RemoveTag(otherPrefab, tag)
       end
     end
 
-    HistoryService:SetWaypoint(constants.waypoints.DELETED)
+    HistoryService:SetWaypoint(constants.waypoints.CLEAN)
   end
 
   exports.deleteSelection = helpers.withSelection(exports.delete)

--- a/src/prefabs.lua
+++ b/src/prefabs.lua
@@ -269,6 +269,7 @@ return function(plugin)
     end
 
     HistoryService:SetWaypoint(constants.waypoints.CLEAN)
+    tagging.clean(tag)
   end
 
   exports.deleteSelection = helpers.withSelection(exports.delete)

--- a/src/tagging.lua
+++ b/src/tagging.lua
@@ -37,7 +37,26 @@ function exports.clean(tag)
       if tagFolder then
         tagFolder:Destroy()
       end
+
+      if #mainTagFolder:GetChildren() == 0 then
+        mainTagFolder:Destroy()
+      end
     end
   end
+
+  -- Additional clean up of TagEditor folders
+  local tagGroupList = ServerStorage:FindFirstChild(constants.tagging.TAG_GROUP_FOLDER_NAME)
+  if tagGroupList then
+    local prefabGroup = tagGroupList:FindFirstChild(constants.tagging.TAG_GROUP_NAME)
+    if prefabGroup then
+      if #prefabGroup:GetChildren() == 0 then
+        prefabGroup:Destroy()
+      end
+    end
+  end
+  if #tagGroupList:GetChildren() == 0 then
+    tagGroupList:Destroy()
+  end
 end
+
 return exports

--- a/src/tagging.lua
+++ b/src/tagging.lua
@@ -18,7 +18,7 @@ end
 -- TODO Add support for removing tags from the editor
 -- When no other prefab tags are present it should also remove the tag group
 function exports.registerWithTagEditor(tag)
-  helpers.mkdir(ServerStorage, "TagGroupList", constants.tagging.TAG_GROUP_NAME)
+  helpers.mkdir(ServerStorage, constants.tagging.TAG_GROUP_FOLDER_NAME, constants.tagging.TAG_GROUP_NAME)
 
   local tagFolder = helpers.mkdir(ServerStorage, constants.tagging.TAG_FOLDER_NAME, tag)
 
@@ -28,4 +28,16 @@ function exports.registerWithTagEditor(tag)
   group.Parent = tagFolder
 end
 
+function exports.clean(tag)
+  local existingTaggedModels = CollectionService:GetTagged(tag)
+  if #existingTaggedModels == 0 then
+    local mainTagFolder = ServerStorage:FindFirstChild(constants.tagging.TAG_FOLDER_NAME)
+    if mainTagFolder then
+      local tagFolder = mainTagFolder:FindFirstChild(tag)
+      if tagFolder then
+        tagFolder:Destroy()
+      end
+    end
+  end
+end
 return exports


### PR DESCRIPTION
When tags are cleaned using prefab.clean, it will remove all instances that use that prefab tag and clean up all TagEditor folders